### PR TITLE
08 ユーザーの詳細ページに投稿一覧を表示する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -98,3 +98,23 @@ img {
 .pagination {
   justify-content: center;
 }
+
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  img{
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+} 

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,5 +1,5 @@
 .col-md-4.mb-3
-/ posts/:idにリンクする
-  = link_to post_path(post), class: 'thumbs' do
-  / 投稿した画像の1枚目を表示
-   = image_tag post.images.first.url
+  / posts/:idにリンクする
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    / 投稿した画像の1枚目を表示
+    = image_tag thumbnail_post.images.first.url

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,5 @@
+.col-md-4.mb-3
+/ posts/:idにリンクする
+  = link_to post_path(post), class: 'thumbs' do
+  / 投稿した画像の1枚目を表示
+   = image_tag post.images.first.url

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -13,7 +13,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,7 +1,7 @@
 / ユーザー詳細ページ
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,6 +8,10 @@
             = image_tag 'profile-placeholder.png', size: '100x100', class: 'rounded-circle mr-1'
           .profile.text-center.mb-3
             = @user.username
-            .text-center
+          .text-center
             / フォロー・アンフォローボタン
-            = render 'follow_area', user: @user
+            = render 'follow_area', user: @user,
+          hr
+          .row
+            / @user.postsの数だけ_thumbnail_post.html.slimが表示される
+            = render partial: 'posts/thumbnail_post', collection: @user.posts

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -10,7 +10,7 @@
             = @user.username
           .text-center
             / フォロー・アンフォローボタン
-            = render 'follow_area', user: @user,
+            = render 'follow_area', user: @user
           hr
           .row
             / @user.postsの数だけ_thumbnail_post.html.slimが表示される


### PR DESCRIPTION
## 概要
ユーザーの詳細ページに投稿一覧を表示するように実装しました。

- タイル表示させる
- ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定してさせる

## コメント
コレクションをレンダリングする方法は初めて使いました。
_thumbnail_post.html.slimで最初`post_path(post)`、`post.images`と書いていたので画像が表示されず躓いてしまったのですが、
Railsガイドの[コレクションをレンダリングする](https://railsguides.jp/layouts_and_rendering.html#%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B)に書いてあるように、

> パーシャルを呼び出す時に指定するコレクションが複数形の場合、パーシャルの個別のインスタンスから、出力するコレクションの個別のメンバにアクセスが行われます。このとき、パーシャル名に基づいた名前を持つ変数が使用されます。

こちらを見て理解することが出来ました。ちゃんと頭に入れておきたいと思います。
ご確認の程よろしくお願いします。
