### PR TITLE
13 通知の設定を実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,9 +4,9 @@ class CommentsController < ApplicationController
   # ログインしているユーザーのコメントを作成し、保存する
   def create
     @comment = current_user.comments.build(comment_params)
-    # コメントした後にメールを送る（comment_post.html.slimの内容）
+    # コメントしている且つ通知設定をしている場合にメールを送る（comment_post.html.slimの内容）
     # user_from（誰から）：ログインしているユーザー（コメントした人）、user_to（誰に）：投稿したユーザー（コメントされた人）
-    UserMailer.with(user_from: current_user, user_to: @comment.post.user, comment: @comment).comment_post.deliver_later if @comment.save
+    UserMailer.with(user_from: current_user, user_to: @comment.post.user, comment: @comment).comment_post.deliver_later if @comment.save && @comment.post.user.notification_on_comment?
   end
 
   # ログインしているユーザーのコメントを探す

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,9 +4,9 @@ class LikesController < ApplicationController
   # パラメータとして渡ってきたpost_idを元にPostテーブルから対象のレコードを取得し、ログインしているユーザーが投稿にいいねする（like_postsにpost_idを追加）
   def create
     @post = Post.find(params[:post_id])
-    # いいねした後にメールを送る（like_post.html.slimの内容）
+    # いいねしている且つ通知設定をしている場合にメールを送る（like_post.html.slimの内容）
     # user_from（誰から）：ログインしているユーザー（いいねした人）、user_to（誰に）：投稿したユーザー（いいねされた人）
-    UserMailer.with(user_from: current_user, user_to: @post.user, post: @post).like_post.deliver_later if current_user.like(@post)
+    UserMailer.with(user_from: current_user, user_to: @post.user, post: @post).like_post.deliver_later if current_user.like(@post) && @post.user.notification_on_like?
   end
 
   # Likeモデルのlike_postsに追加したpost_idを探し、ログインしているユーザーはいいねを削除する

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,5 +1,4 @@
 class Mypage::NotificationSettingsController < Mypage::BaseController
-
   # /mypage/notification_setting/edit
   def edit
     @user = User.find(current_user.id)

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,0 +1,27 @@
+class Mypage::NotificationSettingsController < Mypage::BaseController
+
+  # /mypage/notification_setting/edit
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  # 通知設定を更新する
+  def update
+    @user = User.find(current_user.id)
+    # 設定を更新できた場合
+    if @user.update(notification_setting_params)
+      redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました'
+    # 更新出来なかった場合
+    else
+      flash.now[:danger] = '設定の更新に失敗しました'
+      render :edit
+    end
+  end
+
+  private
+
+  # params[:user][:notification_on_comment],params[:user][:notification_on_like],params[:user][:notification_on_follow]を許可
+  def notification_settings_params
+    params.require(:user).permit(:notification_on_comment, :notification_on_like, :notification_on_follow)
+  end
+end

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -9,7 +9,7 @@ class Mypage::NotificationSettingsController < Mypage::BaseController
   def update
     @user = User.find(current_user.id)
     # 設定を更新できた場合
-    if @user.update(notification_setting_params)
+    if @user.update(notification_settings_params)
       redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました'
     # 更新出来なかった場合
     else

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,9 +4,9 @@ class RelationshipsController < ApplicationController
   # ログインしているユーザーが別のユーザーをフォローする（followingにfollowed_id（フォローされたユーザーのID）を追加する）
   def create
     @user = User.find(params[:followed_id])
-    # フォロー後にメールを送る（follow_user.html.slimの内容）
+    # フォローしている且つ通知設定をしている場合にメールを送る（follow_user.html.slimの内容）
     # user_from（誰から）：ログインしているユーザー（いいねした人）、user_to（誰に）：ユーザー（フォローされた人）
-    UserMailer.with(user_from: current_user, user_to: @user).follow_user.deliver_later if current_user.follow(@user)
+    UserMailer.with(user_from: current_user, user_to: @user).follow.deliver_later if current_user.follow(@user) && @user.notification_on_follow?
   end
 
   # relationshipモデルからフォローしているユーザーを探し（followed_id）、ログインしているユーザーはフォローを解除する

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  action_type  :integer          not null
-#  read         :boolean          default(FALSE), not null
+#  read         :boolean          default("unread"), not null
 #  subject_type :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  avatar           :string(255)
-#  crypted_password :string(255)
-#  email            :string(255)      not null
-#  salt             :string(255)
-#  username         :string(255)      not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 # Indexes
 #

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Mypage::NotificationSettings#edit
+p Find me in app/views/mypage/notification_settings/edit.html.slim

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,2 +1,19 @@
-h1 Mypage::NotificationSettings#edit
-p Find me in app/views/mypage/notification_settings/edit.html.slim
+= form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
+  = render 'shared/error_messages', object: f.object
+
+  // コメントした時の通知設定
+  .form-group
+    = f.check_box :notification_on_comment
+    = f.label :notification_on_comment
+
+  // いいねした時の通知設定
+  .form-group
+    = f.check_box :notification_on_like
+    = f.label :notification_on_like
+
+  // フォローした時の通知設定
+  .form-group
+    = f.check_box :notification_on_follow
+    = f.label :notification_on_follow
+
+= f.submit class: 'btn btn-primary btn-raised'

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -16,4 +16,4 @@
     = f.check_box :notification_on_follow
     = f.label :notification_on_follow
 
-= f.submit class: 'btn btn-primary btn-raised'
+  = f.submit class: 'btn btn-primary btn-raised'

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -6,3 +6,6 @@ nav
     li
       = link_to '通知一覧', mypage_activities_path
       hr
+    li
+      = link_to '通知設定', edit_mypage_notification_setting_path
+      hr

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,9 @@ ja:
         password_confirmation: 'パスワード確認'
         username: 'ユーザー名'
         avatar: 'アバター'
+        notification_on_comment: 'コメント時の通知メール'
+        notification_on_like: 'いいね時の通知メール'
+        notification_on_follow: 'フォロー時の通知メール'
       post:
         images: '画像'
         body: '本文'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,5 +46,7 @@ Rails.application.routes.draw do
     resource :account, only: %i[edit update]
     # 通知
     resources :activities, only: %i[index]
+    # 通知設定
+    resource :notification_setting, only: %i[edit update]
   end
 end

--- a/db/migrate/20200609130253_add_notification_flags_to_users.rb
+++ b/db/migrate/20200609130253_add_notification_flags_to_users.rb
@@ -1,0 +1,7 @@
+class AddNotificationFlagsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :notification_on_comment, :boolean, default: true
+    add_column :users, :notification_on_like, :boolean, default: true
+    add_column :users, :notification_on_follow, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_10_064500) do
+ActiveRecord::Schema.define(version: 2020_06_09_130253) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "action_type", null: false
@@ -71,6 +71,9 @@ ActiveRecord::Schema.define(version: 2020_05_10_064500) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.boolean "notification_on_comment", default: true
+    t.boolean "notification_on_like", default: true
+    t.boolean "notification_on_follow", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
## 概要
通知をするかしないかをユーザーが設定できる機能を実装しました
- マイページに通知設定というメニューを追加
- コメント時の通知メール, いいね時の通知メール, フォロー時の通知メールのオンオフを切り替えられるようにしました

## 確認方法

- カラムを追加したので `bundle exec rails db:migrate` を実行してください

## コメント
今回は特別躓くところはありませんでした。
`http://localhost:3000/letter_opener`と`http://localhost:3000/sidekiq`で動作確認をしております。
ご確認の程よろしくお願いします。